### PR TITLE
fork button and skills layout changes Adrien Brune

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -60,6 +60,7 @@ const Header = ({ t }) => {
       <a
         className="fork-github"
         href="https://github.com/james2001/james2001.github.io"
+        target="_blank" rel="noreferrer"
       >
         <img src={github} alt="#" />
       </a>

--- a/src/style.scss
+++ b/src/style.scss
@@ -9,6 +9,10 @@
 .fork-github {
   display: flex;
   justify-content: end;
+  position: absolute;
+  right: 0;
+  width: 130px;
+  z-index: 1100;
 }
 body {
   font-family: 'Poppins', sans-serif;
@@ -195,7 +199,7 @@ section#qui-suis-je {
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  flex-direction: column;
+  margin-bottom: 100px;
   height: 222px;
 }
 .competences-name {
@@ -207,7 +211,7 @@ section#qui-suis-je {
   width: 35%;
 }
 .competences-part {
-  width: 25%;
+  width: 27%;
 }
 .competences-item-wraper {
   width: 65%;


### PR DESCRIPTION
Pour la partie skills j'ai retiré le flex-direction: column, pour éviter le débordement sur la droite 
et je trouve que les items sont beaucoup plus clairs commen ça, qu'en penses tu?

J'ai rajouté une margin-bottom de 100px;

.competences-wraper {
  display: flex;
  justify-content: space-between;
  flex-wrap: wrap;
  margin-bottom: 100px;
  height: 224px;
}

Pour l'image à cliquer, la class "fixed-top" de tailwind sur la nav bar applique un z-index: 1030
qui recouvrait donc l'image et elle n'était donc cliquable la partie de l'image qui n'était pas recouverte par la div.
Pour corriger le problème j'ai appliqué un z-index plus important sur l'image avec une position absolute
et une width de 130px pour que ça ne couvre pas à son tour la nav.

.fork-github {
  display: flex;
  justify-content: end;
  position: absolute;
  right: 0;
  width: 130px;
  z-index: 1100;
}

Modifié légèrement la width de competences-part pour que les compétences se placent mieux

.competences-part {
  width: 27%;
}

J'ai rajouté un target="_blank" sur le lien pour que ça ouvre directement dans un nouvel onglet

 <a
        className="fork-github"
        href="https://github.com/james2001/james2001.github.io"
        target="_blank" rel="noreferrer"
      >
        <img src={github} alt="#" />
      </a>


Autre amélioration à faire, le responsive de la nav
Pour la nav a 1500 de viewport width l'image fork commence à chevaucher le bouton contact et ça s'empire par la suite.